### PR TITLE
UX: hide core category heading when enabled

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -1,13 +1,15 @@
 @use "lib/viewport";
 
-// hide core  category heading
-.category-heading.--has-logo {
-  display: none;
-}
-
 body:not(.category-header) {
   // hides banners based on outcome of shouldShow
   .category-title-header {
+    display: none;
+  }
+}
+
+body.category-header {
+  // hide core category heading
+  .category-heading {
     display: none;
   }
 }


### PR DESCRIPTION
Prevents a double heading situation...

Before:
<img width="1142" height="412" alt="image" src="https://github.com/user-attachments/assets/da8406d9-a011-4e63-9312-f9895ad69b00" />


After:
<img width="1169" height="351" alt="image" src="https://github.com/user-attachments/assets/56ee7a68-5383-4f1c-9318-3118ab62c9dd" />

Reported: https://meta.discourse.org/t/default-category-heading-not-hidden-when-category-banner-is-used/327519
