### PR TITLE
UX: add missing margin

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -14,6 +14,12 @@ body.category-header {
   }
 }
 
+#main-outlet {
+  .category-title-header {
+    margin-bottom: 1em;
+  }
+}
+
 .category-title-contents {
   display: grid;
   grid-template-areas: "logo title" "logo description";


### PR DESCRIPTION
Missing some margin for the above-main-container outlet 

before
<img width="2286" height="612" alt="image" src="https://github.com/user-attachments/assets/1949ed44-b555-430a-b23e-c91931af129f" />


after
<img width="2322" height="666" alt="image" src="https://github.com/user-attachments/assets/c6adb581-aa51-44da-8c68-d163db348c16" />
